### PR TITLE
Update the version of Fedora

### DIFF
--- a/camflow-vagrant/Vagrantfile
+++ b/camflow-vagrant/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "jhcook/fedora26"
+  config.vm.box = "jhcook/fedora27"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -53,7 +53,7 @@ Vagrant.configure(2) do |config|
    # Customize number of CPU
    vb.cpus = 2
    # Customize VM name
-   vb.name = "CamFlow-rpm"
+   vb.name = "camflow-provmark"
   end
   #
   # View the documentation for the provider you are using for more


### PR DESCRIPTION
Newest CamFlow releases are for Fedora 27.